### PR TITLE
Query

### DIFF
--- a/helpers/chemical.js
+++ b/helpers/chemical.js
@@ -1,0 +1,67 @@
+const models = require('../models');
+const Op = models.Sequelize.Op;
+const chemical = models.chemical;
+
+/**
+ * Class helper for the chemical model that can preform the following
+ */
+class ChemicalHelper {
+  /**
+   * Sets constants for the model helper
+   */
+  constructor() {
+    this.defaultFields = [
+      'Substance_Name',
+      'Substance_CASRN',
+      'Structure_SMILES',
+      'Structure_InChI',
+      'Structure_Formula',
+      'Structure_MolWt',
+    ];
+    this.defaultLimit = 25;
+  }
+
+  /**
+   * Queries using default options
+   * @param  {STRING}  queryString The usrs input non spesific database
+   * @param  {Object}  options This will set the options for the query
+   *                           (Optional)
+   * @param  {integer}  options.limit      How many docs to Returns
+   * @param  {integer}  options.offset     Where to begin the query
+   *                                     (allow user to get next if using limit)
+   * @return {Promise}             Will return error or an array with results
+   *                               of query
+   */
+  async basicQuery(queryString, options) {
+    return new Promise(async (resolve, reject) => {
+      let limit = this.defaultLimit;
+      if (options && options.limit !== undefined && options.limit !== null) {
+        limit = options.limit;
+      }
+
+      let searchParams = [];
+      for (let i = 0; i < this.defaultFields.length; i += 1) {
+        searchParams.push({
+          [this.defaultFields[i]]: {
+            [Op.like]: `%${queryString}%`,
+          },
+        });
+      }
+
+      console.log(searchParams);
+
+      const results = await chemical.findAll(
+        {
+          attributes: this.defaultFields,
+          limit,
+          where: {
+            [Op.or]: searchParams,
+          },
+        }
+      );
+      resolve(results);
+    });
+  }
+}
+
+module.exports = ChemicalHelper;

--- a/helpers/helper.js
+++ b/helpers/helper.js
@@ -1,24 +1,25 @@
 const models = require('../models');
 const Op = models.Sequelize.Op;
-const chemical = models.chemical;
+
+// Limit default on queries
+const DEFAULT_RETURN_LIMIT = 25;
 
 /**
  * Class helper for the chemical model that can preform the following
  */
-class ChemicalHelper {
+class Helper {
   /**
    * Sets constants for the model helper
+   * @param {String}  name          This is the name of the model to use
+   * @param {Array}   defaultFields this is the default SELECT for Queries
+   * @param {Integer} defaultLimit  This is default number of entries returned
+   *                                (Optional) will use constant if not given
    */
-  constructor() {
-    this.defaultFields = [
-      'Substance_Name',
-      'Substance_CASRN',
-      'Structure_SMILES',
-      'Structure_InChI',
-      'Structure_Formula',
-      'Structure_MolWt',
-    ];
-    this.defaultLimit = 25;
+  constructor(name, defaultFields, defaultLimit) {
+    this.modelName = name;
+    this.defaultFields = (defaultFields) ? defaultFields : [];
+    this.defaultLimit = (defaultLimit) ? defaultLimit :
+                                               DEFAULT_RETURN_LIMIT;
   }
 
   /**
@@ -39,6 +40,11 @@ class ChemicalHelper {
         limit = options.limit;
       }
 
+      let offset = 0;
+      if (options && options.offset !== undefined && !isNaN(options.offset)) {
+        offset = options.offset;
+      }
+
       let searchParams = [];
       for (let i = 0; i < this.defaultFields.length; i += 1) {
         searchParams.push({
@@ -48,12 +54,11 @@ class ChemicalHelper {
         });
       }
 
-      console.log(searchParams);
-
-      const results = await chemical.findAll(
+      const results = await models[this.modelName].findAll(
         {
           attributes: this.defaultFields,
           limit,
+          offset,
           where: {
             [Op.or]: searchParams,
           },
@@ -64,4 +69,4 @@ class ChemicalHelper {
   }
 }
 
-module.exports = ChemicalHelper;
+module.exports = Helper;

--- a/helpers/helper.js
+++ b/helpers/helper.js
@@ -5,7 +5,7 @@ const Op = models.Sequelize.Op;
 const DEFAULT_RETURN_LIMIT = 25;
 
 /**
- * Class helper for the chemical model that can preform the following
+ * Class helper for the models that can preform the following
  */
 class Helper {
   /**

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const router = express.Router();
+const jsonResponse = require('../utils/response');
+const Helper = require('../helpers/helper');
+
+// Limit default on queries
+const DEFAULT_RETURN_LIMIT = 25;
+const CHEMICAL_FIELDS = [
+  'Substance_Name',
+  'Substance_CASRN',
+  'Structure_SMILES',
+  'Structure_InChI',
+  'Structure_Formula',
+  'Structure_MolWt',
+];
+const TARGET_FIELDS = [
+  'intended_target_official_full_name',
+  'intended_target_gene_name',
+  'intended_target_official_symbol',
+  'intended_target_gene_symbol',
+  'technological_target_official_full_name',
+  'technological_target_gene_name',
+  'technological_target_official_symbol',
+  'technological_target_gene_symbol',
+];
+
+router.route('/basic')
+  .get(async (req, res) => {
+    let query;
+    let limit;
+    let offset;
+    try {
+      if (req.query && req.query.q) {
+        query = req.query.q;
+      } else {
+        res.status(400).json(new jsonResponse('Must specify a query'));
+      }
+
+      if (req.query && req.query.limit && !isNaN(parseInt(req.query.limit))) {
+        limit = parseInt(req.query.limit);
+      } else {
+        limit = DEFAULT_RETURN_LIMIT;
+      }
+
+      if (req.query && req.query.offset && !isNaN(parseInt(req.query.offset))) {
+        offset = parseInt(req.query.offset);
+      } else {
+        offset = 0;
+      }
+    } catch (err) {
+      res.status(400).json(new jsonResponse(err));
+    }
+
+
+    const chemicalHelper = new Helper(
+      'chemical',
+      CHEMICAL_FIELDS,
+      limit
+    );
+    const targetHelper = new Helper(
+      'target',
+      TARGET_FIELDS,
+      limit
+    );
+
+    const chemResult = chemicalHelper.basicQuery(query, {offset});
+    const targetResult = targetHelper.basicQuery(query, {offset});
+
+    const data = await Promise.all([chemResult, targetResult]);
+    const result = {
+      chemical: data[0],
+      target: data[1],
+    };
+
+    res.status(200).json(new jsonResponse(null, result));
+  });
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const target = require('./routes/target');
 const user = require('./routes/user');
 const citation = require('./routes/citation');
 const chemical = require('./routes/chemical');
-const serach = require('./routes/search');
+const search = require('./routes/search');
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -53,7 +53,7 @@ app.use('/citation', citation);
 app.use('/target', target);
 app.use('/user', user);
 app.use('/chemical', chemical);
-app.use('/search', serach);
+app.use('/search', search);
 
 // error handler
 // no stacktraces leaked to user unless in development environment

--- a/server.js
+++ b/server.js
@@ -13,6 +13,8 @@ const target = require('./routes/target');
 const user = require('./routes/user');
 const citation = require('./routes/citation');
 const chemical = require('./routes/chemical');
+const ChemicalHelper = require('./helpers/chemical');
+const jsonResponse = require('./utils/response');
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -61,6 +63,13 @@ app.use(function(err, req, res, next) {
     message: err.message,
     error: (app.get('env') === 'development') ? err : {},
   });
+});
+
+app.get('/models', async (req, res) => {
+  const chemicalHelper = new ChemicalHelper;
+  const result = await chemicalHelper.basicQuery('ohShit');
+  console.log(result);
+  res.status(200).json(new jsonResponse(null, result));
 });
 
 // Creating a section for dev configs and prod configs

--- a/server.js
+++ b/server.js
@@ -13,8 +13,7 @@ const target = require('./routes/target');
 const user = require('./routes/user');
 const citation = require('./routes/citation');
 const chemical = require('./routes/chemical');
-const ChemicalHelper = require('./helpers/chemical');
-const jsonResponse = require('./utils/response');
+const serach = require('./routes/search');
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -54,6 +53,7 @@ app.use('/citation', citation);
 app.use('/target', target);
 app.use('/user', user);
 app.use('/chemical', chemical);
+app.use('/search', serach);
 
 // error handler
 // no stacktraces leaked to user unless in development environment
@@ -63,13 +63,6 @@ app.use(function(err, req, res, next) {
     message: err.message,
     error: (app.get('env') === 'development') ? err : {},
   });
-});
-
-app.get('/models', async (req, res) => {
-  const chemicalHelper = new ChemicalHelper;
-  const result = await chemicalHelper.basicQuery('ohShit');
-  console.log(result);
-  res.status(200).json(new jsonResponse(null, result));
 });
 
 // Creating a section for dev configs and prod configs


### PR DESCRIPTION
# This seeks to solve the basic needs of #36
 
This is the first implementation of the basic search for all models. It is only hooked up using the two models that were specified in the phase 3 report. 

It currently searches all models no matter what, filtering can be added in later. I feel as though it is in a state where is is usable by the front end team and we can get this version 1 of the search API to them for the presentation.

If the folder structure needs to change (not sure about the helpers folder just request a change). Also in the future I think it would be pretty easy to abstract the /basic route to automate it a bit.