### PR TITLE
Model details

### DIFF
--- a/helpers/helper.js
+++ b/helpers/helper.js
@@ -31,6 +31,30 @@ class Helper {
   }
 
   /**
+   * This will provide a list of all attributes, their types, and if they are
+   * a default field for the model (default fields are included in basic query)
+   * // TODO: Once the relations are in the model that information should be
+   *          added to this functions return
+   * @return {Object} describe object returned here
+   */
+  getAttributeList() {
+    const attributes = models[this.modelName].rawAttributes;
+    const keys = Object.keys(attributes);
+    const arr = [];
+
+    for (let i = 0; i < keys.length; i += 1) {
+      arr.push({
+        'name': keys[i],
+        'type': attributes[keys[i]].type.key,
+        'isDefault': this.defaultFields.includes(keys[i]),
+      });
+    }
+
+    console.log(arr);
+    return arr;
+  }
+
+  /**
    * Queries using default options
    * @param  {STRING}  queryString The usrs input non spesific database
    * @param  {Object}  options This will set the options for the query

--- a/helpers/helper.js
+++ b/helpers/helper.js
@@ -50,7 +50,6 @@ class Helper {
       });
     }
 
-    console.log(arr);
     return arr;
   }
 

--- a/routes/model.js
+++ b/routes/model.js
@@ -23,12 +23,26 @@ const TARGET_FIELDS = [
   'technological_target_official_symbol',
   'technological_target_gene_symbol',
 ];
+const SUPPORTED_MODELS = [
+  'target',
+  'chemical',
+];
 
 router.route('/')
   .get(async (req, res) => {
     let modelName = (req.query.name) ? req.query.name : null;
     if (modelName == null) {
       res.status(400).json(new jsonResponse('A model name must be specified'));
+      return;
+    }
+
+    if (!SUPPORTED_MODELS.includes(modelName)) {
+      res.status(400).json(
+        new jsonResponse(
+          `The ${modelName} is not supported in the detail API`
+        )
+      );
+      return;
     }
 
     let helper;

--- a/routes/model.js
+++ b/routes/model.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const router = express.Router();
+const jsonResponse = require('../utils/response');
+const Helper = require('../helpers/helper');
+
+// Limit default on queries
+const DEFAULT_RETURN_LIMIT = 25;
+const CHEMICAL_FIELDS = [
+  'Substance_Name',
+  'Substance_CASRN',
+  'Structure_SMILES',
+  'Structure_InChI',
+  'Structure_Formula',
+  'Structure_MolWt',
+];
+const TARGET_FIELDS = [
+  'intended_target_official_full_name',
+  'intended_target_gene_name',
+  'intended_target_official_symbol',
+  'intended_target_gene_symbol',
+  'technological_target_official_full_name',
+  'technological_target_gene_name',
+  'technological_target_official_symbol',
+  'technological_target_gene_symbol',
+];
+
+router.route('/')
+  .get(async (req, res) => {
+    let modelName = (req.query.name) ? req.query.name : null;
+    if (modelName == null) {
+      res.status(400).json(new jsonResponse('A model name must be specified'));
+    }
+
+    let helper;
+    if (modelName == 'chemical') {
+      helper = new Helper(
+        'chemical',
+        CHEMICAL_FIELDS,
+        DEFAULT_RETURN_LIMIT
+      );
+    } else if (modelName == 'target') {
+      helper = new Helper(
+        'target',
+        TARGET_FIELDS,
+        DEFAULT_RETURN_LIMIT
+      );
+    }
+
+    const details = helper.getAttributeList();
+    res.status(200).json(new jsonResponse(null, details));
+  });
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -54,6 +54,8 @@ app.use('/target', target);
 app.use('/user', user);
 app.use('/chemical', chemical);
 app.use('/search', search);
+const modelthings = require('./routes/model');
+app.use('/model', modelthings);
 
 // error handler
 // no stacktraces leaked to user unless in development environment


### PR DESCRIPTION
This implements #41 

- The route currently supports target and chemical

### Returns in the form:
```json
{
    "success": true,
    "err": null,
    "payload": [
        {
            "name": "id",
            "type": "INTEGER",
            "isDefault": false
        },
        {
            "name": "DSSTox_Substance_Id",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "DSSTox_Structure_Id",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "DSSTox_QC_Level",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "Substance_Name",
            "type": "STRING",
            "isDefault": true
        },
        {
            "name": "Substance_CASRN",
            "type": "STRING",
            "isDefault": true
        },
        {
            "name": "Substance_Type",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "Substance_Note",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "Structure_SMILES",
            "type": "STRING",
            "isDefault": true
        },
        {
            "name": "Structure_InChI",
            "type": "TEXT",
            "isDefault": true
        },
        {
            "name": "Structure_InChIKey",
            "type": "STRING",
            "isDefault": false
        },
        {
            "name": "Structure_Formula",
            "type": "STRING",
            "isDefault": true
        },
        {
            "name": "Structure_MolWt",
            "type": "DOUBLE PRECISION",
            "isDefault": true
        },
        {
            "name": "createdAt",
            "type": "DATE",
            "isDefault": false
        },
        {
            "name": "updatedAt",
            "type": "DATE",
            "isDefault": false
        }
    ]
}
```